### PR TITLE
feat: add niri as desktop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ At the moment, this installer does not have stable releases. The most recent com
 --Graphics drivers (amd, nvidia, intel, nvidia-nouveau, none)
 --Networking (dhcpcd, NetworkManager, none)
 --Audio server (pipewire, pulseaudio, none)
---DE or WM (gnome, kde, xfce, sway, swayfx, wayfire, i3, none)
+--DE or WM (gnome, kde, xfce, sway, swayfx, wayfire, i3, niri, none)
 --Or, choose to do none of these and install a bare-minimum system
 
 -Option to choose between LVM and a traditional install

--- a/installer.sh
+++ b/installer.sh
@@ -213,13 +213,14 @@ audioConfig() {
 }
 
 desktopConfig() {
-    desktop=$(drawDialog --no-cancel --title "Desktop Environment" --extra-button --extra-label "Map" --menu "" 0 0 0 "gnome" "" "kde" "" "xfce" "" "sway" "" "swayfx" "" "wayfire" "" "i3" "" "none" "")
+    desktop=$(drawDialog --no-cancel --title "Desktop Environment" --extra-button --extra-label "Map" --menu "" 0 0 0 "gnome" "" "kde" "" "xfce" "" "sway" "" "swayfx" "" "wayfire" "" "i3" "" "niri" "" "none" "")
     [ "$?" == "3" ] && dungeonmap
 
     case "$desktop" in
         sway) drawDialog --extra-button --extra-label "Map" --msgbox "Sway will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         swayfx) drawDialog --extra-button --extra-label "Map" --msgbox "SwayFX will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         wayfire) drawDialog --extra-button --extra-label "Map" --msgbox "Wayfire will have to be started manually on login. This can be done by entering 'dbus-run-session wayfire' after logging in on the new installation." 0 0 ;;
+	niri) drawDialog --extra-button --extra-label "Map" --msgbox "Niri will have to be started manually on login. This can be done by entering 'niri --session' after logging in on the new installation." 0 0 ;;
         i3) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install lightdm with i3?" 0 0 && lightdm="Yes" ;;
     esac
 

--- a/installer.sh
+++ b/installer.sh
@@ -220,7 +220,7 @@ desktopConfig() {
         sway) drawDialog --extra-button --extra-label "Map" --msgbox "Sway will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         swayfx) drawDialog --extra-button --extra-label "Map" --msgbox "SwayFX will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         wayfire) drawDialog --extra-button --extra-label "Map" --msgbox "Wayfire will have to be started manually on login. This can be done by entering 'dbus-run-session wayfire' after logging in on the new installation." 0 0 ;;
-        niri) drawDialog --extra-button --extra-label "Map" --msgbox "Niri will have to be started manually on login. This can be done by entering 'niri --session' after logging in on the new installation." 0 0 ;;
+        niri) drawDialog --extra-button --extra-label "Map" --msgbox "Niri will have to be started manually on login. This can be done by entering 'dbus-run-session niri --session' after logging in on the new installation." 0 0 ;;
         i3) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install lightdm with i3?" 0 0 && lightdm="Yes" ;;
     esac
 

--- a/installer.sh
+++ b/installer.sh
@@ -220,7 +220,7 @@ desktopConfig() {
         sway) drawDialog --extra-button --extra-label "Map" --msgbox "Sway will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         swayfx) drawDialog --extra-button --extra-label "Map" --msgbox "SwayFX will have to be started manually on login. This can be done by entering 'dbus-run-session sway' after logging in on the new installation." 0 0 ;;
         wayfire) drawDialog --extra-button --extra-label "Map" --msgbox "Wayfire will have to be started manually on login. This can be done by entering 'dbus-run-session wayfire' after logging in on the new installation." 0 0 ;;
-	niri) drawDialog --extra-button --extra-label "Map" --msgbox "Niri will have to be started manually on login. This can be done by entering 'niri --session' after logging in on the new installation." 0 0 ;;
+        niri) drawDialog --extra-button --extra-label "Map" --msgbox "Niri will have to be started manually on login. This can be done by entering 'niri --session' after logging in on the new installation." 0 0 ;;
         i3) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install lightdm with i3?" 0 0 && lightdm="Yes" ;;
     esac
 

--- a/setup/setupdesktop
+++ b/setup/setupdesktop
@@ -125,12 +125,12 @@ case "$desktop" in
         fi
     ;;
     niri)
-   	install niri elogind polkit polkit-elogind alacritty fuzzel xorg-fonts || die
+        install niri elogind polkit polkit-elogind alacritty fuzzel xorg-fonts || die
 
-	[ "$network" == "NetworkManager" ] &&
-		{ install network-manager-applet || die ;}
-	
-	chroot /mnt /bin/bash -c "ln -s /etc/sv/elogind /var/service && ln -s /etc/sv/polkitd /var/service" || die
+        [ "$network" == "NetworkManager" ] &&
+            { install network-manager-applet || die ;}
+
+        chroot /mnt /bin/bash -c "ln -s /etc/sv/elogind /var/service && ln -s /etc/sv/polkitd /var/service" || die
     ;;
 esac
 

--- a/setup/setupdesktop
+++ b/setup/setupdesktop
@@ -124,6 +124,14 @@ case "$desktop" in
             chroot /mnt /bin/bash -c "ln -s /etc/sv/lightdm /var/service" || die
         fi
     ;;
+    niri)
+   	install niri elogind polkit polkit-elogind alacritty fuzzel xorg-fonts || die
+
+	[ "$network" == "NetworkManager" ] &&
+		{ install network-manager-applet || die ;}
+	
+	chroot /mnt /bin/bash -c "ln -s /etc/sv/elogind /var/service && ln -s /etc/sv/polkitd /var/service" || die
+    ;;
 esac
 
 commandFailure="Audio server installation has failed."


### PR DESCRIPTION
adds the niri wayland compositor as an option in the script. also installs alacritty and fuzzel as its default terminal/app launcher.