### PR TITLE
Add labwc installation option

### DIFF
--- a/setup/chroot
+++ b/setup/chroot
@@ -136,7 +136,7 @@ else
 
     # Create users home directories, such as ~/Downloads
     case "$desktop" in
-        sway|swayfx|wayfire|i3|niri|river)
+        sway|swayfx|wayfire|i3|niri|river|labwc)
             su "$username" -c 'xdg-user-dirs-update' ||
                 { commandFailure="Executing xdg-user-dirs-update has failed." ; die ; }
         ;;

--- a/setup/desktop
+++ b/setup/desktop
@@ -187,6 +187,16 @@ case "$desktop" in
             setup_greetd
             echo 'exec dbus-run-session wayfire "$@"' >> /mnt/usr/local/bin/"${desktop}"-run || die
         fi
+     ;;
+    labwc)
+        install labwc elogind polkit polkit-elogind alacritty xorg-fonts xdg-desktop-portal-wlr xdg-user-dirs
+
+        system "ln -s /etc/sv/polkitd /var/service"
+
+        if [ "$greetd" == "Yes" ]; then
+            setup_greetd
+            echo 'exec dbus-run-session labwc "$@"' >> /mnt/usr/local/bin/"${desktop}"-run || die
+        fi
     ;;
     mate)
         install mate mate-terminal lightdm lightdm-gtk3-greeter xorg-minimal xdg-user-dirs xorg-fonts xorg-video-drivers

--- a/setup/desktop
+++ b/setup/desktop
@@ -187,7 +187,7 @@ case "$desktop" in
             setup_greetd
             echo 'exec dbus-run-session wayfire "$@"' >> /mnt/usr/local/bin/"${desktop}"-run || die
         fi
-     ;;
+    ;;
     labwc)
         install labwc elogind polkit polkit-elogind alacritty xorg-fonts xdg-desktop-portal-wlr xdg-user-dirs
 

--- a/viss
+++ b/viss
@@ -271,7 +271,7 @@ audioConfig() {
 }
 
 desktopConfig() {
-    desktop=$(drawDialog --no-cancel --title "Desktop Environment" --extra-button --extra-label "Map" --menu "" 0 0 0 "gnome" "" "i3" "" "kde" "" "mate" "" "niri" "" "river" "" "sway" "" "swayfx" "" "wayfire" "" "xfce" "" "none" "")
+    desktop=$(drawDialog --no-cancel --title "Desktop Environment" --extra-button --extra-label "Map" --menu "" 0 0 0 "gnome" "" "i3" "" "labwc" "" "kde" "" "mate" "" "niri" "" "river" "" "sway" "" "swayfx" "" "wayfire" "" "xfce" "" "none" "")
     [ "$?" == "3" ] && dungeonmap
 
     case "$desktop" in

--- a/viss
+++ b/viss
@@ -275,7 +275,7 @@ desktopConfig() {
     [ "$?" == "3" ] && dungeonmap
 
     case "$desktop" in
-        sway|swayfx|wayfire|niri|river) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install greetd with $desktop?" 0 0 && greetd="Yes" ;;
+        sway|swayfx|wayfire|niri|river|labwc) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install greetd with $desktop?" 0 0 && greetd="Yes" ;;
         i3) drawDialog --title "" --extra-button --extra-label "Map" --yesno "Would you like to install lightdm with $desktop?" 0 0 && lightdm="Yes" ;;
     esac
 
@@ -375,7 +375,7 @@ confirm() {
     [ "$desktop" == "i3" ] && [ -n "$lightdm" ] &&
         settings+="Install lightdm with i3?: $lightdm\n"
 
-    for i in sway swayfx niri wayfire
+    for i in sway swayfx niri wayfire labwc
     do
         if [ "$desktop" == "$i" ]; then
             [ -z "$greetd" ] && greetd="No"


### PR DESCRIPTION
It genuinely broke my heart to discover that Labwc is no longer an installation option in the void-install-script. For me, it wasn't just another compositor - it embodied the quiet simplicity and minimalism that drew me to Void Linux in the first place. Seeing it disappear leaves an unexpected sense of loss, as though a familiar and comforting part of the experience has quietly faded away. I know projects change and move forward, but I'll deeply miss seeing Labwc as a first-class choice.

aside from ai slop wayfire is missing a few additional packages